### PR TITLE
Updated to new integration structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Sensor plugin for home assistant.
 Read temperature, humidity and atmospheric pressure information from RuuviTag beacons. So far this should work on all Linux based machines with bluez kernel module support. Sensor component uses ruuvitag-sensor library to read values.
 
 ## Installation:
-Copy ruuvitag.py to your .homeassistant/custom_components/sensor/ -directory.
+Copy sensor.py to your .homeassistant/custom_components/ruuvitag/ -directory.
 
 Ensure that hcidump and hcitool are installed on the host machine.
 

--- a/custom_components/ruuvitag/__init__.py
+++ b/custom_components/ruuvitag/__init__.py
@@ -1,0 +1,1 @@
+"""The ruuvitag component."""

--- a/custom_components/ruuvitag/manifest.json
+++ b/custom_components/ruuvitag/manifest.json
@@ -1,0 +1,8 @@
+{
+    "domain": "ruuvitag",
+    "name": "Ruuvitag",
+    "documentation": "https://github.com/pschumi/ruuvitag-sensor",
+    "dependencies": [],
+    "codeowners": [],
+    "requirements": ['ruuvitag_sensor==0.11.0', 'construct==2.9.41']
+  }

--- a/custom_components/ruuvitag/sensor.py
+++ b/custom_components/ruuvitag/sensor.py
@@ -12,13 +12,14 @@ sensor:
 Installation
 ------------
 
-Copy ruuvitag.py to <homeassistanconf>/custom_components/sensor/
+Copy sensor.py to <homeassistanconf>/custom_components/ruuvitag/
 Uses ruuvitag_sensor plugin as dependency so works perfectly only on Linux and expects 
 that hcidump and hcitool are installed.
 
 Version
 -------
 1.0     25.06.2018     First release.
+1.1     05.05.2019     Updated structure for new integration
 
 Created by
 ----------


### PR DESCRIPTION
Updated to the new format needed for HA integrations.
See https://developers.home-assistant.io/blog/2019/04/12/new-integration-structure.html 